### PR TITLE
Bl4 support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,33 @@
+name: Publish to Docker Hub
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/autoshift-scraper:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/autoshift-scraper:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 COPY . /autoshift-scraper/
 WORKDIR /autoshift-scraper

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ docker run -d -t -i \
 -e GITHUB_USER='ugoogalizer' \ 
 -e GITHUB_REPO='autoshift-codes' \
 -e GITHUB_TOKEN='github_pat_***' \
--e PARSER_ARGS='--verbose --schedule 2'+
+-e PARSER_ARGS='--verbose --schedule 2' \
 -v autoshift:/autoshift/data \
 --name autoshift-scraper \
 zacharmstrong/autoshift-scraper:latest
@@ -67,7 +67,7 @@ zacharmstrong/autoshift-scraper:latest
 Example localhost build image: 
 ``` bash
 docker run -d -t -i \
--e GITHUB_USER='ugoogalizer' \
+-e GITHUB_USER='zacharmstrong' \
 -e GITHUB_REPO='autoshift-codes' \
 -e GITHUB_TOKEN='github_pat_***' \
 -e PARSER_ARGS='--verbose --schedule 2' \
@@ -103,12 +103,11 @@ spec:
     spec:
       containers:
         - name: autoshift-scraper
-          # Fix version so it doesn't auto-update
-          image: ugoogalizer/autoshift-scraper:0.6
+          image: zacharmstrong/autoshift-scraper:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: GITHUB_USER
-              value: "ugoogalizer"
+              value: "zarmstrong"
             - name: GITHUB_REPO
               value: "autoshift-codes"
             - name: GITHUB_TOKEN

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Script aimed at scraping SHiFT Codes from websites, currently all provided from 
 - [Borderlands 3](https://mentalmars.com/game-news/borderlands-3-golden-keys/)
 - [Borderlands The Pre-Sequel](https://mentalmars.com/game-news/bltps-golden-keys/)
 - [Tiny Tina's Wonderlands](https://mentalmars.com/game-news/tiny-tinas-wonderlands-shift-codes)
+- [Borderlands 4](https://mentalmars.com/game-news/borderlands-4-shift-codes/)
 
 Instead of publishing this as part of [Fabbi's autoshift](https://github.com/Fabbi/autoshift), this is aimed at publishing a machine readable file that can be hit by autoshift.  This reduces the load on mentalmars as it's likely not ok to have swarms of autoshifts scraping their website.  Instead codes are published to the repo here: 
  - https://github.com/ugoogalizer/autoshift-codes

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Script aimed at scraping SHiFT Codes from websites, currently all provided from 
 - [Borderlands](https://mentalmars.com/game-news/borderlands-golden-keys/)
 - [Borderlands 2](https://mentalmars.com/game-news/borderlands-2-golden-keys/)
 - [Borderlands 3](https://mentalmars.com/game-news/borderlands-3-golden-keys/)
+- [Borderlands 4](https://mentalmars.com/game-news/borderlands-4-shift-codes/)
 - [Borderlands The Pre-Sequel](https://mentalmars.com/game-news/bltps-golden-keys/)
 - [Tiny Tina's Wonderlands](https://mentalmars.com/game-news/tiny-tinas-wonderlands-shift-codes)
-- [Borderlands 4](https://mentalmars.com/game-news/borderlands-4-shift-codes/)
 
 Instead of publishing this as part of [Fabbi's autoshift](https://github.com/Fabbi/autoshift), this is aimed at publishing a machine readable file that can be hit by autoshift.  This reduces the load on mentalmars as it's likely not ok to have swarms of autoshifts scraping their website.  Instead codes are published to the repo here: 
  - https://github.com/ugoogalizer/autoshift-codes
@@ -62,7 +62,7 @@ docker run -d -t -i \
 -e PARSER_ARGS='--verbose --schedule 2'+
 -v autoshift:/autoshift/data \
 --name autoshift-scraper \
-ugoogalizer/autoshift-scraper:latest
+zacharmstrong/autoshift-scraper:latest
 ```
 Example localhost build image: 
 ``` bash

--- a/autoshift-scraper.py
+++ b/autoshift-scraper.py
@@ -72,7 +72,16 @@ webpages= [{
                 "universal",
                 "universal"
             ]
-    }]
+    },{ 
+        "game": "Borderlands 4", 
+        "sourceURL": "https://mentalmars.com/game-news/borderlands-4-shift-codes/",
+        "platform_ordered_tables": [
+                "universal",
+                "universal"
+            ]
+    }
+    
+    ]
 
 def remap_dict_keys(dict_keys):
     # List of table headings to be mapped to standard values
@@ -258,7 +267,7 @@ def generateAutoshiftJSON(website_code_tables, previous_codes, include_expired):
             "version": "0.1",
             "description": "GitHub Alternate Source for Shift Codes",
             "attribution": "Data provided by https://mentalmars.com",
-            "permalink": "https://raw.githubusercontent.com/ugoogalizer/autoshift/master/shiftcodes.json",
+            "permalink": "https://raw.githubusercontent.com/zarmstrong/autoshift-codes/main/shiftcodes.json",
             "generated": {
                 "human": generatedDateAndTime
             },


### PR DESCRIPTION
This pull request updates the scraper to add support for Borderlands 4 SHiFT codes, improves robustness in table parsing, enhances debugging for missing fields, and updates the project to use Python 3.12. The changes also include improvements to key mapping logic and update the attribution permalink.

**Borderlands 4 support:**
- Added Borderlands 4 to the list of supported games in `README.md` and to the `webpages` configuration in `autoshift-scraper.py`, enabling scraping of SHiFT codes for this game. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10) [[2]](diffhunk://#diff-50af97917623fa2f3a43b7e8c6c21196a0a31943b03cd0ea79698081a8c6d2a5R15-R32)

**Scraping robustness and debugging:**
- Improved handling in `scrape_codes` to avoid `IndexError` when more tables are found than expected, logging a warning and skipping extra tables.
- Enhanced debugging in `generateAutoshiftJSON` by logging and saving problematic code rows with missing critical fields to a debug file for later inspection.

**Key mapping and data quality:**
- Refactored `remap_dict_keys` to use case-insensitive substring checks for more flexible mapping of table headings to canonical keys, accommodating more heading variations.

**Metadata and compatibility:**
- Changed the Docker base image from Python 3.10 to Python 3.12 for improved compatibility and support.
- Updated the `permalink` in the output JSON metadata to point to the new repository location.